### PR TITLE
Add Circle CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+      
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: install yarn
+          command: 'sudo npm install -g yarn --quiet'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
+      - run:
+          name: yarn install
+          command: 'yarn install --pure-lockfile --no-progress'
+      - save_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+      - run:
+          name: test
+          command: 'yarn test'
+      - run:
+          name: build
+          command: 'yarn build'
+      - store_artifacts:
+          path: dist

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # InfluxDB (Flux) Datasource [BETA] -  Native Plugin
 
+[![CircleCI](https://circleci.com/gh/grafana/influxdb-flux-datasource/tree/master.svg?style=svg)](https://circleci.com/gh/grafana/influxdb-flux-datasource/tree/master)
+
 Grafana ships with **built in** support for InfluxDB (>= 1.4.1).
 
 Use this datasource if you want to use Flux to query your InfluxDB.


### PR DESCRIPTION
I'm hoping this plugin can serve as a template for best-practice external plugin configurations/setup.  It would be great to have a plugin configured that validates pull requests.  

This adds a circleci config -- it needs to be updated so that the tests actually pass/fail the build.

FYI, right now for me on a clean system:
```
yarn install
yarn test
```
great!

```
$ yarn dev
yarn run v1.6.0
$ webpack --mode development
clean-webpack-plugin: C:\workspace\grafana-plugins\influxdb-flux-datasource\dist has been removed.
Hash: 7aa1a576614eccafca13
....

ERROR in C:\workspace\grafana-plugins\influxdb-flux-datasource\src\datasource.ts
./datasource.ts
[tsl] ERROR in C:\workspace\grafana-plugins\influxdb-flux-datasource\src\datasource.ts(3,27)
      TS2307: Cannot find module 'app/core/utils/datemath'.

ERROR in C:\workspace\grafana-plugins\influxdb-flux-datasource\src\query_ctrl.ts
./query_ctrl.ts
[tsl] ERROR in C:\workspace\grafana-plugins\influxdb-flux-datasource\src\query_ctrl.ts(1,23)
      TS2307: Cannot find module 'app/core/app_events'.

ERROR in C:\workspace\grafana-plugins\influxdb-flux-datasource\src\query_ctrl.ts
./query_ctrl.ts
[tsl] ERROR in C:\workspace\grafana-plugins\influxdb-flux-datasource\src\query_ctrl.ts(2,27)
      TS2307: Cannot find module 'app/plugins/sdk'.

...
```

I tried on osx and also got errors.


