### PR TITLE
Fixes for slate, and queries grouped by time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [5.4.0] - 2019-10-09
+
+- Slate fixes for Grafana 6.4.x
+- Fix for queries which group by time, and return _start and _stop rather than _time
 
 ## [5.3.2] - 2019-07-07
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "moment": "2.24.0",
     "papaparse": "4.6.3",
     "prismjs": "1.16.0",
+    "ts-loader": "^6.2.0",
+    "typescript": "^3.6.3",
     "shelljs": "^0.8.3",
-    "slate": "0.47.4",
-    "slate-plain-serializer": "0.7.6",
-    "slate-react": "0.22.4"
+    "slate": "0.47.8",
+    "slate-plain-serializer": "0.7.10",
+    "@grafana/slate-react": "^0.22.9-grafana"
   },
   "devDependencies": {
     "@grafana/toolkit": "next",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
     "prismjs": "1.16.0",
     "ts-loader": "^6.2.0",
     "typescript": "^3.6.3",
-    "shelljs": "^0.8.3",
-    "slate": "0.47.8",
-    "slate-plain-serializer": "0.7.10",
-    "@grafana/slate-react": "^0.22.9-grafana"
+    "shelljs": "^0.8.3"
   },
   "devDependencies": {
     "@grafana/toolkit": "next",
     "@grafana/ui": "latest",
     "@types/grafana": "github:CorpGlory/types-grafana.git",
-    "@types/slate-plain-serializer": "^0.6.1"
+    "@types/slate-plain-serializer": "^0.6.1",
+    "slate": "0.47.8",
+    "slate-plain-serializer": "0.7.10",
+    "@grafana/slate-react": "^0.22.9-grafana"
   }
 }

--- a/src/editor/FluxQueryField.tsx
+++ b/src/editor/FluxQueryField.tsx
@@ -193,10 +193,10 @@ export default class FluxQueryField extends QueryField {
         return group;
       });
 
-      console.log('handleTypeahead')
+      console.log('handleTypeahead');
       console.log('anchornode', selection.anchorNode);
       console.log('wrapperClasses', wrapperClasses);
-      console.log('text', text); 
+      console.log('text', text);
       console.log('offset', offset);
       console.log('prefix', prefix);
       console.log('typeaheadContext', typeaheadContext);
@@ -213,10 +213,7 @@ export default class FluxQueryField extends QueryField {
     }
   }, 500);
 
-  applyTypeahead = (
-    editor: CoreEditor, 
-    suggestion: { text: any; type: string; deleteBackwards: any },
-  ): CoreEditor => {
+  applyTypeahead = (editor: CoreEditor, suggestion: { text: any; type: string; deleteBackwards: any }): CoreEditor => {
     const { typeaheadPrefix, typeaheadContext, typeaheadText } = this.state;
     let suggestionText = suggestion.text || suggestion;
     const move = 0;

--- a/src/editor/FluxQueryField.tsx
+++ b/src/editor/FluxQueryField.tsx
@@ -193,14 +193,6 @@ export default class FluxQueryField extends QueryField {
         return group;
       });
 
-      console.log('handleTypeahead');
-      console.log('anchornode', selection.anchorNode);
-      console.log('wrapperClasses', wrapperClasses);
-      console.log('text', text);
-      console.log('offset', offset);
-      console.log('prefix', prefix);
-      console.log('typeaheadContext', typeaheadContext);
-
       this.setState({
         typeaheadPrefix: prefix,
         typeaheadContext,

--- a/src/editor/QueryField.tsx
+++ b/src/editor/QueryField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Block, Document, Text, Value } from 'slate';
-import { Editor } from 'slate-react';
+import { Block, Document, Text, Value, Editor as CoreEditor } from 'slate';
+import { Editor } from '@grafana/slate-react';
 import Plain from 'slate-plain-serializer';
 
 import BracesPlugin from './slate-plugins/braces';
@@ -143,19 +143,21 @@ class QueryField extends React.Component<any, any> {
   handleChangeQuery = () => {
     // Send text change to parent
     const { onQueryChange } = this.props;
+    console.log("handleChangeQuery", onQueryChange, this.state);
     if (onQueryChange) {
       onQueryChange(Plain.serialize(this.state.value));
     }
   };
 
-  onKeyDown = (event, change) => {
+  onKeyDown = (event: Event, editor: CoreEditor, next: Function) => {
     const { typeaheadIndex, suggestions } = this.state;
+    const keyboardEvent = event as KeyboardEvent;
 
-    switch (event.key) {
+    switch (keyboardEvent.key) {
       case 'Escape': {
         if (this.menuEl) {
-          event.preventDefault();
-          event.stopPropagation();
+          keyboardEvent.preventDefault();
+          keyboardEvent.stopPropagation();
           this.resetTypeahead();
           return true;
         }
@@ -163,8 +165,8 @@ class QueryField extends React.Component<any, any> {
       }
 
       case ' ': {
-        if (event.ctrlKey) {
-          event.preventDefault();
+        if (keyboardEvent.ctrlKey) {
+          keyboardEvent.preventDefault();
           this.handleTypeahead();
           return true;
         }
@@ -177,7 +179,7 @@ class QueryField extends React.Component<any, any> {
           // Dont blur input
           event.preventDefault();
           if (!suggestions || suggestions.length === 0) {
-            return undefined;
+            return next();
           }
 
           // Get the currently selected suggestion
@@ -186,7 +188,7 @@ class QueryField extends React.Component<any, any> {
           const selectedIndex = selected % flattenedSuggestions.length || 0;
           const suggestion = flattenedSuggestions[selectedIndex];
 
-          this.applyTypeahead(change, suggestion);
+          this.applyTypeahead(editor, suggestion);
           return true;
         }
         break;
@@ -215,16 +217,19 @@ class QueryField extends React.Component<any, any> {
         break;
       }
     }
-    return undefined;
+    return next();
   };
 
   handleTypeahead = (change?, item?) => {
     return change || this.state.value.change();
   };
 
-  applyTypeahead(change?, suggestion?): { value: object } {
-    return { value: {} };
-  }
+  applyTypeahead = (
+    editor: CoreEditor,
+    suggestion: { text: any; type: string; deleteBackwards: any },
+  ): { value: object } => {
+    return { value: new Value() };
+  };
 
   resetTypeahead = () => {
     this.setState({
@@ -252,9 +257,10 @@ class QueryField extends React.Component<any, any> {
     }
   };
 
-  handleClickMenu = item => {
+  handleClickMenu = (item, editor: CoreEditor) => {
     // Manually triggering change
-    const change = this.applyTypeahead(this.state.value.change(), item);
+    console.log("handleClickMenu")
+    const change = this.applyTypeahead(editor, item);
     this.onChange(change);
   };
 

--- a/src/editor/QueryField.tsx
+++ b/src/editor/QueryField.tsx
@@ -143,7 +143,6 @@ class QueryField extends React.Component<any, any> {
   handleChangeQuery = () => {
     // Send text change to parent
     const { onQueryChange } = this.props;
-    console.log('handleChangeQuery', onQueryChange, this.state);
     if (onQueryChange) {
       onQueryChange(Plain.serialize(this.state.value));
     }
@@ -213,7 +212,6 @@ class QueryField extends React.Component<any, any> {
       }
 
       default: {
-        // console.log('default key', event.key, event.which, event.charCode, event.locale, data.key);
         break;
       }
     }
@@ -256,7 +254,6 @@ class QueryField extends React.Component<any, any> {
 
   handleClickMenu = (item, editor: CoreEditor) => {
     // Manually triggering change
-    console.log('handleClickMenu');
     const change = this.applyTypeahead(editor, item);
     this.onChange(change);
   };

--- a/src/editor/QueryField.tsx
+++ b/src/editor/QueryField.tsx
@@ -143,7 +143,7 @@ class QueryField extends React.Component<any, any> {
   handleChangeQuery = () => {
     // Send text change to parent
     const { onQueryChange } = this.props;
-    console.log("handleChangeQuery", onQueryChange, this.state);
+    console.log('handleChangeQuery', onQueryChange, this.state);
     if (onQueryChange) {
       onQueryChange(Plain.serialize(this.state.value));
     }
@@ -224,10 +224,7 @@ class QueryField extends React.Component<any, any> {
     return change || this.state.value.change();
   };
 
-  applyTypeahead = (
-    editor: CoreEditor,
-    suggestion: { text: any; type: string; deleteBackwards: any },
-  ): { value: object } => {
+  applyTypeahead = (editor: CoreEditor, suggestion: { text: any; type: string; deleteBackwards: any }): { value: object } => {
     return { value: new Value() };
   };
 
@@ -259,7 +256,7 @@ class QueryField extends React.Component<any, any> {
 
   handleClickMenu = (item, editor: CoreEditor) => {
     // Manually triggering change
-    console.log("handleClickMenu")
+    console.log('handleClickMenu');
     const change = this.applyTypeahead(editor, item);
     this.onChange(change);
   };

--- a/src/editor/Typeahead.tsx
+++ b/src/editor/Typeahead.tsx
@@ -37,7 +37,7 @@ class TypeaheadItem extends React.PureComponent<any, any> {
 
 class TypeaheadGroup extends React.PureComponent<any, any> {
   render() {
-    const { items, label, selected, onClickItem } = this.props;
+    const { items, label, selected, onClickItem, editor } = this.props;
     return (
       <li className="typeahead-group">
         <div className="typeahead-group__title">{label}</div>
@@ -45,7 +45,16 @@ class TypeaheadGroup extends React.PureComponent<any, any> {
           {items.map(item => {
             const text = typeof item === 'object' ? item.text : item;
             const label = typeof item === 'object' ? item.display || item.text : item;
-            return <TypeaheadItem key={text} onClickItem={onClickItem} isSelected={selected.indexOf(text) > -1} hint={item.hint} label={label} />;
+            return (
+              <TypeaheadItem
+                key={text}
+                onClickItem={onClickItem}
+                isSelected={selected.indexOf(text) > -1}
+                hint={item.hint}
+                label={label}
+                editor={editor}
+              />
+            );
           })}
         </ul>
       </li>
@@ -55,11 +64,11 @@ class TypeaheadGroup extends React.PureComponent<any, any> {
 
 class Typeahead extends React.PureComponent<any, any> {
   render() {
-    const { groupedItems, menuRef, selectedItems, onClickItem } = this.props;
+    const { groupedItems, menuRef, selectedItems, onClickItem, editor } = this.props;
     return (
       <ul className="typeahead" ref={menuRef}>
         {groupedItems.map(g => (
-          <TypeaheadGroup key={g.label} onClickItem={onClickItem} selected={selectedItems} {...g} />
+          <TypeaheadGroup key={g.label} onClickItem={onClickItem} selected={selectedItems} editor={editor} {...g} />
         ))}
       </ul>
     );

--- a/src/editor/editor_component.tsx
+++ b/src/editor/editor_component.tsx
@@ -45,7 +45,7 @@ class Editor extends Component<any, any> {
           initialQuery={edited ? null : query}
           onPressEnter={this.handlePressEnter}
           onQueryChange={this.handleChangeQuery}
-          prismLanguage="python"
+          prismLanguage="flux"
           prismDefinition={flux}
           placeholder="Enter a FLUX query"
           request={request}

--- a/src/editor/slate-plugins/braces.ts
+++ b/src/editor/slate-plugins/braces.ts
@@ -30,14 +30,8 @@ export default function BracesPlugin(): Plugin {
               .insertTextByKey(startKey, startOffset, event.key)
               .insertTextByKey(endKey, endOffset + 1, BRACES[event.key])
               .moveEndBackward(1);
-          } else if (
-            focusOffset === text.length ||
-            text[focusOffset] === ' ' ||
-            Object.values(BRACES).includes(text[focusOffset])
-          ) {
-            editor
-              .insertText(`${event.key}${BRACES[event.key]}`)
-              .moveBackward(1);
+          } else if (focusOffset === text.length || text[focusOffset] === ' ' || Object.values(BRACES).includes(text[focusOffset])) {
+            editor.insertText(`${event.key}${BRACES[event.key]}`).moveBackward(1);
           } else {
             editor.insertText(event.key);
           }
@@ -46,7 +40,7 @@ export default function BracesPlugin(): Plugin {
         }
 
         case 'Backspace': {
-          console.log("backspace");
+          console.log('backspace');
           const text = value.anchorText.text;
           const offset = value.selection.anchor.offset;
           const previousChar = text[offset - 1];

--- a/src/editor/slate-plugins/braces.ts
+++ b/src/editor/slate-plugins/braces.ts
@@ -40,7 +40,6 @@ export default function BracesPlugin(): Plugin {
         }
 
         case 'Backspace': {
-          console.log('backspace');
           const text = value.anchorText.text;
           const offset = value.selection.anchor.offset;
           const previousChar = text[offset - 1];

--- a/src/editor/slate-plugins/braces.ts
+++ b/src/editor/slate-plugins/braces.ts
@@ -1,51 +1,73 @@
-const BRACES = {
+import { Plugin } from '@grafana/slate-react';
+import { Editor as CoreEditor } from 'slate';
+
+const BRACES: any = {
   '[': ']',
   '{': '}',
   '(': ')',
 };
 
-export default function BracesPlugin() {
+export default function BracesPlugin(): Plugin {
   return {
-    onKeyDown(event, change) {
-      const { value } = change;
-      if (!value.isCollapsed) {
-        return undefined;
-      }
+    onKeyDown(event: KeyboardEvent, editor: CoreEditor, next: Function) {
+      const { value } = editor;
 
       switch (event.key) {
+        case '(':
         case '{':
         case '[': {
           event.preventDefault();
-          // Insert matching braces
-          change
-            .insertText(`${event.key}${BRACES[event.key]}`)
-            .move(-1)
-            .focus();
+          const {
+            start: { offset: startOffset, key: startKey },
+            end: { offset: endOffset, key: endKey },
+            focus: { offset: focusOffset },
+          } = value.selection;
+          const text = value.focusText.text;
+
+          // If text is selected, wrap selected text in parens
+          if (value.selection.isExpanded) {
+            editor
+              .insertTextByKey(startKey, startOffset, event.key)
+              .insertTextByKey(endKey, endOffset + 1, BRACES[event.key])
+              .moveEndBackward(1);
+          } else if (
+            focusOffset === text.length ||
+            text[focusOffset] === ' ' ||
+            Object.values(BRACES).includes(text[focusOffset])
+          ) {
+            editor
+              .insertText(`${event.key}${BRACES[event.key]}`)
+              .moveBackward(1);
+          } else {
+            editor.insertText(event.key);
+          }
+
           return true;
         }
 
-        case '(': {
-          event.preventDefault();
+        case 'Backspace': {
+          console.log("backspace");
           const text = value.anchorText.text;
-          const offset = value.anchorOffset;
-          const space = text.indexOf(' ', offset);
-          const length = space > 0 ? space : text.length;
-          const forward = length - offset;
-          // Insert matching braces
-          change
-            .insertText(event.key)
-            .move(forward)
-            .insertText(BRACES[event.key])
-            .move(-1 - forward)
-            .focus();
-          return true;
+          const offset = value.selection.anchor.offset;
+          const previousChar = text[offset - 1];
+          const nextChar = text[offset];
+          if (BRACES[previousChar] && BRACES[previousChar] === nextChar) {
+            event.preventDefault();
+            // Remove closing brace if directly following
+            editor
+              .deleteBackward(1)
+              .deleteForward(1)
+              .focus();
+            return true;
+          }
         }
 
         default: {
           break;
         }
       }
-      return undefined;
+
+      return next();
     },
   };
 }

--- a/src/editor/slate-plugins/clear.ts
+++ b/src/editor/slate-plugins/clear.ts
@@ -1,22 +1,26 @@
+import { Plugin } from '@grafana/slate-react';
+import { Editor as CoreEditor } from 'slate';
+
 // Clears the rest of the line after the caret
-export default function ClearPlugin() {
+export default function ClearPlugin(): Plugin {
   return {
-    onKeyDown(event, change) {
-      const { value } = change;
-      if (!value.isCollapsed) {
-        return undefined;
+    onKeyDown(event: KeyboardEvent, editor: CoreEditor, next: Function) {
+      const value = editor.value;
+
+      if (value.selection.isExpanded) {
+        return next();
       }
 
       if (event.key === 'k' && event.ctrlKey) {
         event.preventDefault();
         const text = value.anchorText.text;
-        const offset = value.anchorOffset;
+        const offset = value.selection.anchor.offset;
         const length = text.length;
         const forward = length - offset;
-        change.deleteForward(forward);
+        editor.deleteForward(forward);
         return true;
       }
-      return undefined;
+      return next();
     },
   };
 }

--- a/src/editor/slate-plugins/newline.ts
+++ b/src/editor/slate-plugins/newline.ts
@@ -1,5 +1,8 @@
+import { Plugin } from '@grafana/slate-react';
+import { Editor as CoreEditor } from 'slate';
+
 function getIndent(text) {
-  let offset = text.length - text.trimLeft().length;
+  let offset = text.length - text.trimStart().length;
   if (offset) {
     let indent = text[0];
     while (--offset) {
@@ -10,12 +13,13 @@ function getIndent(text) {
   return '';
 }
 
-export default function NewlinePlugin() {
+export default function NewlinePlugin(): Plugin {
   return {
-    onKeyDown(event, change) {
-      const { value } = change;
-      if (!value.isCollapsed) {
-        return undefined;
+    onKeyDown(event: KeyboardEvent, editor: CoreEditor, next: Function) {
+      const value = editor.value;
+
+      if (value.selection.isExpanded) {
+        return next();
       }
 
       if (event.key === 'Enter' && event.shiftKey) {
@@ -25,11 +29,13 @@ export default function NewlinePlugin() {
         const currentLineText = startBlock.text;
         const indent = getIndent(currentLineText);
 
-        return change
+        return editor
           .splitBlock()
           .insertText(indent)
           .focus();
       }
+
+      return next();
     },
   };
 }

--- a/src/editor/slate-plugins/prism/index.tsx
+++ b/src/editor/slate-plugins/prism/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import Prism from 'prismjs';
+import { Decoration } from 'slate';
+import { Editor } from '@grafana/slate-react';
 
 const TOKEN_MARK = 'prism-token';
 
-export function setPrismTokens(language, field, values, alias = 'variable') {
+export function setPrismTokens(language: string, field: string | number, values: any, alias = 'variable') {
   Prism.languages[language][field] = {
     alias,
     pattern: new RegExp(`(?:^|\\s)(${values.join('|')})(?:$|\\s)`),
@@ -17,7 +19,7 @@ export function setPrismTokens(language, field, values, alias = 'variable') {
  * (Adapted to handle nested grammar definitions.)
  */
 
-export default function PrismPlugin({ definition, language }) {
+export default function PrismPlugin({ definition, language }: { definition: any; language: string }) {
   if (definition) {
     // Don't override exising modified definitions
     Prism.languages[language] = Prism.languages[language] || definition;
@@ -31,13 +33,13 @@ export default function PrismPlugin({ definition, language }) {
      * @return {Element}
      */
 
-    renderMark(props) {
-      const { children, mark } = props;
+    renderDecoration(props: any, editor: Editor, next: () => any): JSX.Element {
+      const { children, decoration } = props;
       // Only apply spans to marks identified by this plugin
-      if (mark.type !== TOKEN_MARK) {
-        return undefined;
+      if (decoration.type !== TOKEN_MARK) {
+        return next();
       }
-      const className = `token ${mark.data.get('types')}`;
+      const className = `token ${decoration.data.get('types')}`;
       return <span className={className}>{children}</span>;
     },
 
@@ -48,23 +50,23 @@ export default function PrismPlugin({ definition, language }) {
      * @return {Array}
      */
 
-    decorateNode(node) {
+    decorateNode(node: any, editor: Editor, next: () => any): any[] {
       if (node.type !== 'paragraph') {
         return [];
       }
 
       const texts = node.getTexts().toArray();
-      const tstring = texts.map(t => t.text).join('\n');
+      const tstring = texts.map((t: { text: any }) => t.text).join('\n');
       const grammar = Prism.languages[language];
       const tokens = Prism.tokenize(tstring, grammar);
-      const decorations: any[] = [];
+      const decorations: Decoration[] = [];
       let startText = texts.shift();
       let endText = startText;
       let startOffset = 0;
       let endOffset = 0;
       let start = 0;
 
-      function processToken(token, acc?) {
+      function processToken(token: any, acc?: string) {
         // Accumulate token types down the tree
         const types = `${acc || ''} ${token.type || ''} ${token.alias || ''}`;
 
@@ -92,13 +94,18 @@ export default function PrismPlugin({ definition, language }) {
 
           // Inject marks from up the tree (acc) as well
           if (typeof token !== 'string' || acc) {
-            const range = {
-              anchorKey: startText.key,
-              anchorOffset: startOffset,
-              focusKey: endText.key,
-              focusOffset: endOffset,
-              marks: [{ type: TOKEN_MARK, data: { types } }],
-            };
+            const range = node.createDecoration({
+              anchor: {
+                key: startText.key,
+                offset: startOffset,
+              },
+              focus: {
+                key: endText.key,
+                offset: endOffset,
+              },
+              type: TOKEN_MARK,
+              data: { types },
+            });
 
             decorations.push(range);
           }

--- a/src/editor/slate-plugins/runner.ts
+++ b/src/editor/slate-plugins/runner.ts
@@ -1,6 +1,8 @@
-export default function RunnerPlugin({ handler }) {
+import { Editor as SlateEditor } from 'slate';
+
+export default function RunnerPlugin({ handler }: any) {
   return {
-    onKeyDown(event) {
+    onKeyDown(event: KeyboardEvent, editor: SlateEditor, next: Function) {
       // Handle enter
       if (handler && event.key === 'Enter' && !event.shiftKey) {
         // Submit on Enter
@@ -8,7 +10,7 @@ export default function RunnerPlugin({ handler }) {
         handler(event);
         return true;
       }
-      return undefined;
+      return next();
     },
   };
 }

--- a/src/editor/utils/dom.ts
+++ b/src/editor/utils/dom.ts
@@ -1,7 +1,7 @@
 // Node.closest() polyfill
 if ('Element' in window && !Element.prototype.closest) {
   Element.prototype.closest = function(this: any, s: string) {
-    console.log("This is", this);
+    console.log('This is', this);
     const matches = (this.document || this.ownerDocument).querySelectorAll(s);
     let el = this;
     let i;
@@ -17,7 +17,7 @@ if ('Element' in window && !Element.prototype.closest) {
 }
 
 export function getPreviousCousin(node: any, selector: string) {
-  console.log("Entering getPreviousCousin");
+  console.log('Entering getPreviousCousin');
   let sibling = node.parentElement.previousSibling;
   let el;
   while (sibling) {
@@ -32,7 +32,7 @@ export function getPreviousCousin(node: any, selector: string) {
 }
 
 export function getNextCharacter(global = window) {
-  console.log("Entering getNextCharacter");
+  console.log('Entering getNextCharacter');
   const selection = global.getSelection();
   if (!selection || !selection.anchorNode) {
     return null;

--- a/src/editor/utils/dom.ts
+++ b/src/editor/utils/dom.ts
@@ -1,6 +1,7 @@
 // Node.closest() polyfill
 if ('Element' in window && !Element.prototype.closest) {
   Element.prototype.closest = function(this: any, s: string) {
+    console.log("This is", this);
     const matches = (this.document || this.ownerDocument).querySelectorAll(s);
     let el = this;
     let i;
@@ -16,6 +17,7 @@ if ('Element' in window && !Element.prototype.closest) {
 }
 
 export function getPreviousCousin(node: any, selector: string) {
+  console.log("Entering getPreviousCousin");
   let sibling = node.parentElement.previousSibling;
   let el;
   while (sibling) {
@@ -25,10 +27,12 @@ export function getPreviousCousin(node: any, selector: string) {
     }
     sibling = sibling.previousSibling;
   }
+  console.log('returning undefined');
   return undefined;
 }
 
 export function getNextCharacter(global = window) {
+  console.log("Entering getNextCharacter");
   const selection = global.getSelection();
   if (!selection || !selection.anchorNode) {
     return null;
@@ -36,6 +40,9 @@ export function getNextCharacter(global = window) {
 
   const range = selection.getRangeAt(0);
   const text = selection.anchorNode.textContent;
+  if (text === null) {
+    return null;
+  }
   const offset = range.startOffset;
   return text!.substr(offset, 1);
 }

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -56,7 +56,6 @@ export class InfluxFluxQueryCtrl extends QueryCtrl {
   };
 
   onChange = nextQuery => {
-    console.log('nextQuery', nextQuery);
     this.target.query = nextQuery;
   };
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -60,7 +60,6 @@ export class InfluxFluxQueryCtrl extends QueryCtrl {
   };
 
   onExecute = () => {
-    console.log('Influx refresh metric data', this.target);
     this.panelCtrl.refresh();
   };
 

--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -158,6 +158,16 @@ export function getTableModelFromResult(result: string) {
   return table;
 }
 
+function getTimeRec(record) {
+  if (typeof record['_time'] !== "undefined") {
+    return record['_time'];
+  }
+
+  if (typeof record['_start'] !== "undefined") {
+    return record['_start'];
+  }
+}
+
 export function getTimeSeriesFromResult(result: string) {
   const { data } = parseCSV(result);
   if (data.length === 0) {
@@ -169,7 +179,7 @@ export function getTimeSeriesFromResult(result: string) {
   const seriesList = Object.keys(tables)
     .map(id => tables[id])
     .map(series => {
-      const datapoints = series.map(record => [parseValue(record['_value']), parseTime(record['_time'])]);
+      const datapoints = series.map(record => [parseValue(record['_value']), parseTime(getTimeRec(record))]);
       const alias = getNameFromRecord(series[0]);
       return { datapoints, target: alias };
     });

--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -159,11 +159,11 @@ export function getTableModelFromResult(result: string) {
 }
 
 function getTimeRec(record) {
-  if (typeof record['_time'] !== "undefined") {
+  if (typeof record['_time'] !== 'undefined') {
     return record['_time'];
   }
 
-  if (typeof record['_start'] !== "undefined") {
+  if (typeof record['_start'] !== 'undefined') {
     return record['_start'];
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,6 +713,28 @@
   resolved "https://registry.yarnpkg.com/@grafana/data/-/data-6.4.0-beta.1.tgz#1864b552932eaf27b6b1d6d630d69975d2614d7e"
   integrity sha512-wY2VgAO8b1dLn2qXBi3c3ENWsGglns/NaiWTDVXSorSfJlvH8jTrDt6Rn7iRXSiLsD8cJ0vZ2djg+5AvYpupng==
 
+"@grafana/slate-react@^0.22.9-grafana":
+  version "0.22.9-grafana"
+  resolved "https://registry.yarnpkg.com/@grafana/slate-react/-/slate-react-0.22.9-grafana.tgz#07f35f0ffc018f616b9f82fa6e5ba65fae75c6a0"
+  integrity sha512-9NYjwabVOUQ/e4Y/Wm+sgePM65rb/gju59D52t4O42HsIm9exXv+SLajEBF/HiLHzuH5V+5uuHajbzv0vuE2VA==
+  dependencies:
+    debug "^3.1.0"
+    get-window "^1.1.1"
+    is-window "^1.0.2"
+    lodash "^4.1.1"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.8"
+    react-immutable-proptypes "^2.1.0"
+    selection-is-backward "^1.0.0"
+    slate-base64-serializer "^0.2.111"
+    slate-dev-environment "^0.2.2"
+    slate-hotkeys "^0.2.9"
+    slate-plain-serializer "^0.7.10"
+    slate-prop-types "^0.5.41"
+    slate-react-placeholder "^0.2.8"
+    tiny-invariant "^1.0.1"
+    tiny-warning "^0.0.3"
+
 "@grafana/toolkit@next":
   version "6.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/@grafana/toolkit/-/toolkit-6.4.0-beta.1.tgz#2eb190f5fe13c4b0e183d8c5944f557c08c2ca1d"
@@ -8834,7 +8856,7 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
-slate-base64-serializer@^0.2.107:
+slate-base64-serializer@^0.2.111:
   version "0.2.111"
   resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.2.111.tgz#22ba7d32aa4650f6bbd25c26ffe11f5d021959d6"
   integrity sha512-pEsbxz4msVSCCCkn7rX+lHXxUj/oddcR4VsIYwWeQQLm9Uw7Ovxja4rQ/hVFcQqoU2DIjITRwBR9pv3RyS+PZQ==
@@ -8856,52 +8878,25 @@ slate-hotkeys@^0.2.9:
     is-hotkey "0.1.4"
     slate-dev-environment "^0.2.2"
 
-slate-plain-serializer@0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.7.6.tgz#b9d092ddfb3415cc61920e1748caae3afed066f7"
-  integrity sha512-PHCV8RDulthgE5BnySf1PqjG6UEwXYSPjfe++FToeSZRAApd/MHTcMyvQ/m1GdliP/yEWN1X3+TUyO42QlNvRg==
-
-slate-plain-serializer@^0.7.6:
+slate-plain-serializer@0.7.10, slate-plain-serializer@^0.7.10:
   version "0.7.10"
   resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.7.10.tgz#bc4a6942cf52fde826019bb1095dffd0dac8cc08"
   integrity sha512-/QvMCQ0F3NzbnuoW+bxsLIChPdRgxBjQeGhYhpRGTVvlZCLOmfDvavhN6fHsuEwkvdwOmocNF30xT1WVlmibYg==
 
-slate-prop-types@^0.5.37:
+slate-prop-types@^0.5.41:
   version "0.5.41"
   resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.5.41.tgz#42031881e2fef4fa978a96b9aad84b093b4a5219"
   integrity sha512-fLcXlugO9btF5b/by+dA+n8fn2mET75VGWltqFNxGdl6ncyBtrGspWA7mLVRFSqQWOS/Ig4A3URCRumOBBCUfQ==
 
-slate-react-placeholder@^0.2.4:
+slate-react-placeholder@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/slate-react-placeholder/-/slate-react-placeholder-0.2.8.tgz#973ac47c9a518a1418e89b6021b0f6120c07ce6f"
   integrity sha512-CZZSg5usE2ZY/AYg06NVcL9Wia6hD/Mg0w4D4e9rPh6hkkFJg8LZXYMRz+6Q4v1dqHmzRsZ2Ixa0jRuiKXsMaQ==
 
-slate-react@0.22.4:
-  version "0.22.4"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.22.4.tgz#2ffa9a5cd54752fe1434e33cb8cd74d0f2e98d22"
-  integrity sha512-XGLMRMtbL6ndQOLAkhKgXfsgv9dPuIxhEQOXGr440pEUojAKGeYjtkRYV1iHFMkDhb9k3GmyjAN9zkqivBLnEw==
-  dependencies:
-    debug "^3.1.0"
-    get-window "^1.1.1"
-    is-window "^1.0.2"
-    lodash "^4.1.1"
-    memoize-one "^4.0.0"
-    prop-types "^15.5.8"
-    react-immutable-proptypes "^2.1.0"
-    selection-is-backward "^1.0.0"
-    slate-base64-serializer "^0.2.107"
-    slate-dev-environment "^0.2.2"
-    slate-hotkeys "^0.2.9"
-    slate-plain-serializer "^0.7.6"
-    slate-prop-types "^0.5.37"
-    slate-react-placeholder "^0.2.4"
-    tiny-invariant "^1.0.1"
-    tiny-warning "^0.0.3"
-
-slate@0.47.4:
-  version "0.47.4"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.47.4.tgz#9c8e7a73dac78d14615c68c576f0cfd2338daa84"
-  integrity sha512-kyZDN0NgjCtfYm2CrWZ7FixoO+dA6M3EFDb5q+Ig6zEmnt9IUKT1AlRNwN2mWCqTpRSY3SxEdgoUuzbvbUScUg==
+slate@0.47.8:
+  version "0.47.8"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.47.8.tgz#1e987b74d8216d44ec56154f0e6d3c722ce21e6e"
+  integrity sha512-/Jt0eq4P40qZvtzeKIvNb+1N97zVICulGQgQoMDH0TI8h8B+5kqa1YeckRdRnuvfYJm3J/9lWn2V3J1PrF+hag==
   dependencies:
     debug "^3.1.0"
     direction "^0.1.5"
@@ -9607,6 +9602,17 @@ ts-loader@6.0.4:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
+ts-loader@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.0.tgz#52d3993ecbc5474c1513242388e1049da0fce880"
+  integrity sha512-Da8h3fD+HiZ9GvZJydqzk3mTC9nuOKYlJcpuk+Zv6Y1DPaMvBL+56GRzZFypx2cWrZFMsQr869+Ua2slGoLxvQ==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
+
 ts-node@^8.2.0:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
@@ -9697,6 +9703,11 @@ typescript@3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
+typescript@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
- Fixes for slate and Grafana 6.4.2
- Fixes for flux queries grouped by time. In this case queries return `_start` and `_stop` rather than `_time`.

Still testing.