### PR TITLE
Make the MAX_SERIES limit a plugin parameter.

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -18,6 +18,7 @@ export default class InfluxDatasource {
   interval: any;
   supportAnnotations: boolean;
   supportMetrics: boolean;
+  maxSeries: number;
 
   /** @ngInject */
   constructor(instanceSettings, private backendSrv, private templateSrv) {
@@ -34,6 +35,7 @@ export default class InfluxDatasource {
     this.bucket = (instanceSettings.jsonData || {}).bucket;
     this.supportAnnotations = true;
     this.supportMetrics = true;
+    this.maxSeries = (instanceSettings.jsonData || {}).maxSeries || MAX_SERIES;
   }
 
   prepareQueryTarget(target, options) {
@@ -68,8 +70,12 @@ export default class InfluxDatasource {
     });
 
     return Promise.all(queries).then((series: any) => {
-      const seriesList = _.flattenDeep(series).slice(0, MAX_SERIES);
-      return { data: seriesList };
+      const seriesList = _.flattenDeep(series);
+      if (this.maxSeries > 0) {
+        return { data: seriesList.slice(0, this.maxSeries) };
+      } else {
+        return { data: seriesList };
+      }
     });
   }
 

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -4,6 +4,7 @@
 <h3 class="page-heading">InfluxDB 2.0.0 Details</h3>
 
 <div class="gf-form-group">
+
 	<div class="gf-form max-width-25">
 			<span class="gf-form-label width-10">Organization</span>
 			<input type="text" class="gf-form-input" ng-model='ctrl.current.jsonData.organization' required></input>
@@ -33,4 +34,18 @@
 		<input type="text" class="gf-form-input max-width-12" disabled="disabled" value="configured">
 		<a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.current.secureJsonFields.token = false">reset</a>
 	</div>
+</div>
+
+<h3 class="page-heading">Plugin configuration</h3>
+
+<div class="gf-form-group">
+
+	<div class="gf-form max-width-25">
+		<span class="gf-form-label width-15">Max number of series (0..N)</span>
+		<input type="number" class="gf-form-input" ng-model='ctrl.current.jsonData.maxSeries' min="0" step="1" required></input>
+		<info-popover mode="right-absolute">
+			<p>The max number of series this plugin will display per query. 0 means no limit.</p>
+		</info-popover>
+	</div>
+
 </div>


### PR DESCRIPTION
Add a new plugin parameter to change the maximum number of series that will be passed to the frontend.

The current value of 120 is kept for:
- backward compatibility (after the plugin update, no value will be set, so 120 will still be used);
- incorrect value set in the configuration panel (only round positive number are correct values).

Fixes https://github.com/grafana/influxdb-flux-datasource/issues/31