### PR TITLE
Support aggregate output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [7.0.1] - 2020-05-17
 
 - Support results without a measurment name
+- use release influxdb client
 
 
 ## [7.0.0] - 2020-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log
 
-## [7.0.0] - 2020-???
+
+## [7.0.1] - 2020-05-17
+
+- Support results without a measurment name
+
+
+## [7.0.0] - 2020-05-17
 
 - Migrated to grafana backend plugin
+- Signed for grafana 7.x
+- Optimized for copy/paste from influxdb 2.0 data explorer.
 
 
 ## [5.4.1] - 2019-10-28

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/influxdb-flux-datasource
 go 1.14
 
 require (
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.4.1
 	github.com/grafana/grafana-plugin-sdk-go v0.66.0
-	github.com/influxdata/influxdb-client-go v1.1.1-0.20200511153144-e63a28ffeba7
+	github.com/influxdata/influxdb-client-go v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.14
 
 require (
 	github.com/google/go-cmp v0.4.0
-	github.com/grafana/grafana-plugin-sdk-go v0.65.0
+	github.com/grafana/grafana-plugin-sdk-go v0.66.0
 	github.com/influxdata/influxdb-client-go v1.1.1-0.20200511153144-e63a28ffeba7
 )

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/google/flatbuffers v1.11.0 h1:O7CEyB8Cb3/DmtxODGtLHcEvpr81Jm5qLg/hsHn
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
+github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/grafana/grafana-plugin-sdk-go v0.66.0 h1:Tx8pchA74QUtxtN8moavf0FJoAZbnbW3Fe8RVfSKUoY=
 github.com/grafana/grafana-plugin-sdk-go v0.66.0/go.mod h1:w855JyiC5PDP3naWUJP0h/vY8RlzlE4+4fodyoXph+4=
@@ -64,8 +64,8 @@ github.com/hashicorp/go-plugin v1.2.2/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYt
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/influxdata/influxdb-client-go v1.1.1-0.20200511153144-e63a28ffeba7 h1:4Inzo/mjTMm7DdqVNkbHmEo6UIwQDpWHMYdlu4+I/W4=
-github.com/influxdata/influxdb-client-go v1.1.1-0.20200511153144-e63a28ffeba7/go.mod h1:ZVjaPW87aKp5hzyny2WVpWVF0UY+iqtPz9veOZ2T1zw=
+github.com/influxdata/influxdb-client-go v1.2.0 h1:QiRg4BX9KYM28rVxUTk3MQM0mYOMayxC+rM9tGVk1C0=
+github.com/influxdata/influxdb-client-go v1.2.0/go.mod h1:ZVjaPW87aKp5hzyny2WVpWVF0UY+iqtPz9veOZ2T1zw=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/grafana/grafana-plugin-sdk-go v0.65.0 h1:l6cPKCFxf3AN3gd7Sprum2TuhcqsGI98Xa/1dDuin9E=
-github.com/grafana/grafana-plugin-sdk-go v0.65.0/go.mod h1:w855JyiC5PDP3naWUJP0h/vY8RlzlE4+4fodyoXph+4=
+github.com/grafana/grafana-plugin-sdk-go v0.66.0 h1:Tx8pchA74QUtxtN8moavf0FJoAZbnbW3Fe8RVfSKUoY=
+github.com/grafana/grafana-plugin-sdk-go v0.66.0/go.mod h1:w855JyiC5PDP3naWUJP0h/vY8RlzlE4+4fodyoXph+4=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 h1:0IKlLyQ3Hs9nDaiK5cSHAGmcQEIC8l2Ts1u6x5Dfrqg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -64,8 +64,6 @@ github.com/hashicorp/go-plugin v1.2.2/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYt
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/influxdata/influxdb-client-go v1.1.1-0.20200504153954-46f54361f3fd h1:Tw8cDqqGNVZg+UXe1fcTrDOd3xZ39VlxhYkCwnlWwJU=
-github.com/influxdata/influxdb-client-go v1.1.1-0.20200504153954-46f54361f3fd/go.mod h1:ZVjaPW87aKp5hzyny2WVpWVF0UY+iqtPz9veOZ2T1zw=
 github.com/influxdata/influxdb-client-go v1.1.1-0.20200511153144-e63a28ffeba7 h1:4Inzo/mjTMm7DdqVNkbHmEo6UIwQDpWHMYdlu4+I/W4=
 github.com/influxdata/influxdb-client-go v1.1.1-0.20200511153144-e63a28ffeba7/go.mod h1:ZVjaPW87aKp5hzyny2WVpWVF0UY+iqtPz9veOZ2T1zw=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=

--- a/pkg/influx/builder.go
+++ b/pkg/influx/builder.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/api/query"
 
 	"github.com/grafana/influxdb-flux-datasource/pkg/converters"
 )
@@ -74,7 +74,7 @@ func getConverter(t string) (*data.FieldConverter, error) {
 // Init initializes the frame to be returned
 // fields points at entries in the frame, and provides easier access
 // names indexes the columns encountered
-func (fb *FrameBuilder) Init(metadata *influxdb2.FluxTableMetadata) error {
+func (fb *FrameBuilder) Init(metadata *query.FluxTableMetadata) error {
 	columns := metadata.Columns()
 	fb.frames = make([]*data.Frame, 0)
 	fb.tableId = -1
@@ -121,7 +121,7 @@ func (fb *FrameBuilder) Init(metadata *influxdb2.FluxTableMetadata) error {
 // Tags are appended as labels
 // _measurement holds the dataframe name
 // _field holds the field name.
-func (fb *FrameBuilder) Append(record *influxdb2.FluxRecord) error {
+func (fb *FrameBuilder) Append(record *query.FluxRecord) error {
 	table, ok := record.ValueByKey("table").(int64)
 	if ok && table != fb.tableId {
 		fb.totalSeries++

--- a/pkg/influx/builder_test.go
+++ b/pkg/influx/builder_test.go
@@ -5,24 +5,6 @@ import (
 )
 
 func TestColumnIdentification(t *testing.T) {
-	t.Run("Test Field Identification", func(t *testing.T) {
-		fieldNames := []string{"_time", "_value", "_measurement", "_field", "_start", "_stop"}
-		for _, item := range fieldNames {
-			if !isField.MatchString(item) {
-				t.Fatal("Field", item, "Expected field, but got false")
-			}
-		}
-	})
-
-	t.Run("Test Not Field Identification", func(t *testing.T) {
-		fieldNames := []string{"_header", "_cpu", "_hello", "_doctor"}
-		for _, item := range fieldNames {
-			if isField.MatchString(item) {
-				t.Fatal("Field", item, "Expected NOT a field, but got true")
-			}
-		}
-	})
-
 	t.Run("Test Tag Identification", func(t *testing.T) {
 		tagNames := []string{"header", "value", "tag"}
 		for _, item := range tagNames {

--- a/pkg/influx/datasource.go
+++ b/pkg/influx/datasource.go
@@ -10,22 +10,23 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource"
 	"github.com/grafana/influxdb-flux-datasource/pkg/models"
 	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/api"
 	"github.com/influxdata/influxdb-client-go/domain"
 )
 
 // This is an interface to help testing
 type queryRunner interface {
-	runQuery(ctx context.Context, q string) (*influxdb2.QueryTableResult, error)
+	runQuery(ctx context.Context, q string) (*api.QueryTableResult, error)
 	checkHealth(ctx context.Context) (*domain.HealthCheck, error)
 }
 
-// This is an interface to help testing
+// InfluxRunner This is an interface to help testing
 type InfluxRunner struct {
 	client influxdb2.Client
 	org    string
 }
 
-func (r *InfluxRunner) runQuery(ctx context.Context, q string) (*influxdb2.QueryTableResult, error) {
+func (r *InfluxRunner) runQuery(ctx context.Context, q string) (*api.QueryTableResult, error) {
 	return r.client.QueryApi(r.org).Query(ctx, q)
 }
 func (r *InfluxRunner) checkHealth(ctx context.Context) (*domain.HealthCheck, error) {
@@ -57,7 +58,7 @@ func (s *instanceSettings) Dispose() {
 	// to cleanup.
 }
 
-// NewRelicDS ...
+// InfluxDataSource ...
 type InfluxDataSource struct {
 	im instancemgmt.InstanceManager
 }

--- a/pkg/influx/executor.go
+++ b/pkg/influx/executor.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/influxdb-flux-datasource/pkg/models"
-	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/api"
 )
 
+// ExecuteQuery execute a query
 func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunner, maxSeries int) (dr backend.DataResponse) {
 	dr = backend.DataResponse{}
 
@@ -27,7 +28,7 @@ func ExecuteQuery(ctx context.Context, query models.QueryModel, runner queryRunn
 	return readDataFrames(tables, int(float64(query.MaxDataPoints)*1.5), maxSeries)
 }
 
-func readDataFrames(result *influxdb2.QueryTableResult, maxPoints int, maxSeries int) (dr backend.DataResponse) {
+func readDataFrames(result *api.QueryTableResult, maxPoints int, maxSeries int) (dr backend.DataResponse) {
 	dr = backend.DataResponse{}
 
 	builder := &FrameBuilder{

--- a/pkg/influx/executor_test.go
+++ b/pkg/influx/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/influxdb-flux-datasource/pkg/models"
 )
 
@@ -114,6 +115,43 @@ func TestExecuteGrouping(t *testing.T) {
 		st, _ := dr.Frames[0].StringTable(-1, -1)
 		fmt.Println(st)
 		fmt.Println("----------------------")
+	})
+}
+
+func TestAggregateGrouping(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Grouping Test", func(t *testing.T) {
+		runner := &MockRunner{
+			testDataPath: "aggregate.csv",
+		}
+
+		dr := ExecuteQuery(ctx, models.QueryModel{MaxDataPoints: 100}, runner, 50)
+
+		if dr.Error != nil {
+			t.Fatal(dr.Error)
+		}
+
+		str, _ := dr.Frames[0].StringTable(-1, -1)
+		fmt.Println(str)
+
+		expect := `Name: 
+Dimensions: 2 Fields by 3 Rows
++-------------------------------+--------------------------+
+| Name: Time                    | Name:                    |
+| Labels:                       | Labels: host=hostname.ru |
+| Type: []time.Time             | Type: []*float64         |
++-------------------------------+--------------------------+
+| 2020-06-05 12:06:00 +0000 UTC | 8.291381590647958        |
+| 2020-06-05 12:07:00 +0000 UTC | 0.5341565263056448       |
+| 2020-06-05 12:08:00 +0000 UTC | 0.6676119389260387       |
++-------------------------------+--------------------------+
+`
+
+		if diff := cmp.Diff(str, expect); diff != "" {
+			t.Fatalf("mismatch %s (-want +got):\n%s", "aggregate.csv", diff)
+		}
+
 	})
 }
 

--- a/pkg/influx/mock.go
+++ b/pkg/influx/mock.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/api"
 	"github.com/influxdata/influxdb-client-go/domain"
 )
 
@@ -21,7 +22,7 @@ type MockRunner struct {
 	testDataPath string
 }
 
-func (r *MockRunner) runQuery(ctx context.Context, q string) (*influxdb2.QueryTableResult, error) {
+func (r *MockRunner) runQuery(ctx context.Context, q string) (*api.QueryTableResult, error) {
 	bytes, err := ioutil.ReadFile("./testdata/" + r.testDataPath)
 	if err != nil {
 		return nil, err
@@ -43,5 +44,5 @@ func (r *MockRunner) runQuery(ctx context.Context, q string) (*influxdb2.QueryTa
 }
 
 func (r *MockRunner) checkHealth(ctx context.Context) (*domain.HealthCheck, error) {
-	return nil, fmt.Errorf("not implemented yet!")
+	return nil, fmt.Errorf("not implemented yet")
 }

--- a/pkg/influx/testdata/aggregate.csv
+++ b/pkg/influx/testdata/aggregate.csv
@@ -1,0 +1,7 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,double
+#group,false,false,true,true,false,true,false
+#default,_result,,,,,,
+,result,table,_start,_stop,_time,host,_value
+,,0,2020-06-05T12:03:27.444072266Z,2020-06-05T12:08:27.444072266Z,2020-06-05T12:06:00Z,hostname.ru,8.291381590647958
+,,0,2020-06-05T12:03:27.444072266Z,2020-06-05T12:08:27.444072266Z,2020-06-05T12:07:00Z,hostname.ru,0.5341565263056448
+,,0,2020-06-05T12:03:27.444072266Z,2020-06-05T12:08:27.444072266Z,2020-06-05T12:08:00Z,hostname.ru,0.6676119389260387

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -17,7 +17,7 @@ const samples: Array<SelectableValue<string>> = [
     label: 'Simple query',
     description: 'filter by measurment and field',
     value: `from(bucket: "db/rp")
-  |> range(start: v.timeRangeStart, stop:timeRangeStop)
+  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)
   |> filter(fn: (r) =>
     r._measurement == "example-measurement" and
     r._field == "example-field"


### PR DESCRIPTION
This PR does 3 things (sorry should be 3 PRs... but leaving on vacation tomorrow!)

1. Supports results that do not have a `_measurement` field
2. Uses the 1.2.0 release version of the influx client
3. Attaches the executed query to metadata so it will be visible in the query inspector (v7.1)