### PR TITLE
Store DefaultBucket setting in DatasourceSettings

### DIFF
--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -11,9 +11,10 @@ import (
 // InfluxSettings contains config properties (share with other AWS services?)
 type DatasourceSettings struct {
 	// Loaded from root object
-	URL          string
-	Token        string
-	Organization string
+	URL           string
+	Token         string
+	Organization  string
+	DefaultBucket string `json:"defaultBucket"`
 
 	// Loaded from jsonData
 	MaxSeries int `json:"maxSeries"`


### PR DESCRIPTION
I'm working to get the datasource to load from a yaml file, rather than relying on the use of the UI. This bit of data seems to be missing.

I'll submit an example to the readme once I get this working.  The yaml I have right now is:

```
# config file version
apiVersion: 1

# list of datasources to insert/update depending
# what's available in the database
datasources:
  # <string, required> name of the datasource. Required
- name: InfluxDB
  # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required
  access: proxy
  version: 1
  editable: false
  isDefault: true
  orgId: 1
  defaultBucket: rpi-sensors
  organization: <org>
  url: https://us-central1-1.gcp.cloud2.influxdata.com/
  type: grafana-influxdb-flux-datasource
  secureJsonData:
    token: <token>
```

I dug out the type from plugin.json: https://github.com/grafana/influxdb-flux-datasource/blob/master/src/plugin.json#L4 and it seems to work.